### PR TITLE
Build for ghc-9.2 using CPP.

### DIFF
--- a/src/ThoralfPlugin/Encode.hs
+++ b/src/ThoralfPlugin/Encode.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE CPP #-}
+
 module ThoralfPlugin.Encode ( thoralfTheories ) where
 
 
+#if MIN_VERSION_ghc(9, 2, 0)
+import GHC.Tc.Plugin ( TcPluginM )
+#else
 import TcRnTypes( TcPluginM )
+#endif
 
 import ThoralfPlugin.Encode.TheoryEncoding
 

--- a/src/ThoralfPlugin/Encode/Bool.hs
+++ b/src/ThoralfPlugin/Encode/Bool.hs
@@ -1,9 +1,22 @@
-{-# LANGUAGE TypeFamilies, TypeInType, TypeOperators,
+{-# LANGUAGE CPP,
+    TypeFamilies, TypeInType, TypeOperators,
     GADTs, RecordWildCards, StandaloneDeriving
 #-}
 
 module ThoralfPlugin.Encode.Bool ( boolTheory ) where
 
+#if MIN_VERSION_ghc(9, 2, 0)
+import GHC.Builtin.Types ( boolTyCon, promotedTrueDataCon, promotedFalseDataCon )
+import GHC.Plugins ( TyCon, mkTcOcc )
+import GHC.Core.Type ( Type, splitTyConApp_maybe )
+import GHC.Tc.Plugin
+                 ( tcLookupTyCon, lookupOrig
+                 , findImportedModule, FindResult(..)
+                 , TcPluginM
+                 )
+import GHC.Unit.Module ( Module, mkModuleName )
+import GHC.Data.FastString ( fsLit )
+#else
 import TysWiredIn ( boolTyCon, promotedTrueDataCon, promotedFalseDataCon )
 
 import TyCon ( TyCon(..) )
@@ -18,6 +31,7 @@ import Type ( Type, splitTyConApp_maybe )
 import OccName ( mkTcOcc )
 import Module ( Module, mkModuleName )
 import FastString ( fsLit )
+#endif
 
 import ThoralfPlugin.Encode.TheoryEncoding
 

--- a/src/ThoralfPlugin/Encode/Symbol.hs
+++ b/src/ThoralfPlugin/Encode/Symbol.hs
@@ -1,15 +1,27 @@
-{-# LANGUAGE TypeFamilies, TypeInType, TypeOperators,
+{-# LANGUAGE CPP,
+    TypeFamilies, TypeInType, TypeOperators,
     GADTs, RecordWildCards, StandaloneDeriving
 #-}
 
 module ThoralfPlugin.Encode.Symbol ( symbolTheory ) where
 
-import Type ( Type,
+#if MIN_VERSION_ghc(9, 2, 0)
+import GHC.Core.Type
+            ( Type,
+              splitTyConApp_maybe, isStrLitTy
+            )
+import GHC.Tc.Plugin ( TcPluginM )
+import GHC.Data.FastString (unpackFS)
+import GHC.Builtin.Types ( typeSymbolKindCon )
+#else 
+import Type
+            ( Type,
               splitTyConApp_maybe, isStrLitTy
             )
 import TcPluginM ( TcPluginM )
 import FastString ( unpackFS )
 import TysWiredIn ( typeSymbolKindCon )
+#endif
 
 
 import ThoralfPlugin.Encode.TheoryEncoding

--- a/src/ThoralfPlugin/Encode/TheoryEncoding.hs
+++ b/src/ThoralfPlugin/Encode/TheoryEncoding.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE TypeFamilies       #-}
 {-# LANGUAGE TypeInType         #-}
 {-# LANGUAGE TypeOperators      #-}
@@ -18,8 +19,13 @@ module ThoralfPlugin.Encode.TheoryEncoding
 
 
 import Control.Applicative ( (<|>) )
+#if MIN_VERSION_ghc(9, 2, 0)
+import GHC.Core.Type ( Type, Kind, TyVar )
+import GHC.Tc.Plugin ( TcPluginM )
+#else 
 import Type ( Type, Kind, TyVar )
-import TcRnTypes( TcPluginM )
+import TcRnTypes ( TcPluginM )
+#endif
 import Data.Vec
 
 

--- a/src/ThoralfPlugin/Encode/UoM.hs
+++ b/src/ThoralfPlugin/Encode/UoM.hs
@@ -1,9 +1,21 @@
-{-# LANGUAGE TypeFamilies, TypeInType, TypeOperators,
+{-# LANGUAGE CPP,
+    TypeFamilies, TypeInType, TypeOperators,
     GADTs, RecordWildCards, StandaloneDeriving
 #-}
 
 module ThoralfPlugin.Encode.UoM ( uomTheory ) where
 
+#if MIN_VERSION_ghc(9, 2, 0)
+import GHC.Plugins ( TyCon, mkTcOcc )
+import GHC.Core.Type ( Type, splitTyConApp_maybe )
+import GHC.Tc.Plugin
+                 ( tcLookupTyCon, lookupOrig
+                 , findImportedModule, FindResult(..)
+                 , TcPluginM
+                 )
+import GHC.Unit.Module ( Module, mkModuleName )
+import GHC.Data.FastString ( fsLit )
+#else
 import TyCon ( TyCon(..) )
 import Type ( Type, splitTyConApp_maybe )
 import TcPluginM ( tcLookupTyCon, lookupOrig
@@ -13,6 +25,7 @@ import TcPluginM ( tcLookupTyCon, lookupOrig
 import OccName ( mkTcOcc )
 import Module ( Module, mkModuleName )
 import FastString ( fsLit )
+#endif
 
 import ThoralfPlugin.Encode.TheoryEncoding
 

--- a/src/ThoralfPlugin/Plugin.hs
+++ b/src/ThoralfPlugin/Plugin.hs
@@ -1,9 +1,15 @@
+{-# LANGUAGE CPP #-}
 
 module ThoralfPlugin.Plugin ( plugin ) where
 
 
+#if MIN_VERSION_ghc(9, 2, 0)
+import GHC.Plugins ( Plugin (..), defaultPlugin )
+import GHC.Tc.Types ( TcPlugin(..) )
+#else
 import GhcPlugins ( Plugin (..), defaultPlugin )
 import TcRnTypes  ( TcPlugin (..) )
+#endif
 
 import ThoralfPlugin.Encode ( thoralfTheories )
 import ThoralfPlugin.ThoralfPlugin ( thoralfPlugin )

--- a/src/ThoralfPlugin/Theory/Bool.hs
+++ b/src/ThoralfPlugin/Theory/Bool.hs
@@ -9,6 +9,7 @@ module ThoralfPlugin.Theory.Bool where
 import GHC.TypeLits ( Nat )
 
 type family (<?) (x :: Nat) (y :: Nat) :: Bool where {}
+type family (<=?) (x :: Nat) (y :: Nat) :: Bool where {}
 
 
 

--- a/src/ThoralfPlugin/Theory/UoM.hs
+++ b/src/ThoralfPlugin/Theory/UoM.hs
@@ -8,7 +8,6 @@ module ThoralfPlugin.Theory.UoM (
   One, IsBase, IsProd, IsDiv
   ) where
 
-import GHC.Types ( Symbol )
 import Data.Kind ( Constraint )
 import GHC.TypeLits
 

--- a/src/ThoralfPlugin/ThoralfPlugin.hs
+++ b/src/ThoralfPlugin/ThoralfPlugin.hs
@@ -14,18 +14,39 @@ module ThoralfPlugin.ThoralfPlugin ( thoralfPlugin ) where
 
 -- Simple imports:
 import Prelude hiding ( showList )
-import FastString ( fsLit )
 import Data.Maybe ( mapMaybe )
 import Data.List ( intersperse, (\\) )
 import qualified Data.Map.Strict as M
 import qualified Data.Set as Set
 import qualified SimpleSMT as SMT
-import Class ( Class(..) )
 import System.IO.Error
 import Data.IORef ( IORef )
 
 
 -- GHC API imports:
+#if MIN_VERSION_ghc(9, 2, 0)
+import GHC.Builtin.Names ( getUnique )
+import GHC.Core.Coercion ( Role(..), Var, mkUnivCo )
+import GHC.Core.Type ( Type, splitTyConApp_maybe )
+import GHC.Core.TyCo.Rep ( UnivCoProvenance(PluginProv) )
+import GHC.Plugins ( TyCon, mkTcOcc, getTyVar_maybe )
+import GHC.Unit.Module ( Module, mkModuleName )
+import GHC.Data.FastString ( fsLit )
+import GHC.Core.Class ( Class )
+import GHC.Tc.Plugin
+                 ( TcPluginM
+                 , tcPluginIO, lookupOrig, tcLookupClass
+                 , findImportedModule, FindResult(..), zonkCt
+                 , unsafeTcPluginTcM )
+import GHC.Tc.Types ( TcPlugin(..), TcPluginResult(..) )
+import GHC.Types.Var ( isTcTyVar )
+import GHC.Tc.Types.Constraint ( Ct, WantedConstraints(..) )
+import GHC.Tc.Types.Evidence ( EvTerm(..), evCoercion )
+import GHC.Utils.Outputable ( showSDocUnsafe, ppr )
+import GHC.Tc.Utils.TcType ( isMetaTyVar )
+import GHC.Plugins ( getOccName, occNameString )
+import GHC.Data.IOEnv ( newMutVar, readMutVar, writeMutVar )
+#else
 import GhcPlugins ( getUnique, getOccName )
 import TcPluginM ( tcPluginIO, lookupOrig, tcLookupClass
                  , findImportedModule, FindResult(..), zonkCt
@@ -50,6 +71,9 @@ import Module ( Module, mkModuleName )
 import OccName ( mkTcOcc, occNameString )
 import Outputable ( showSDocUnsafe, ppr )
 import IOEnv ( newMutVar, readMutVar, writeMutVar )
+import FastString ( fsLit )
+import Class ( Class(..) )
+#endif
 
 
 -- Internal Imports

--- a/src/ThoralfPlugin/Variables.hs
+++ b/src/ThoralfPlugin/Variables.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE TypeOperators #-}
@@ -7,8 +8,15 @@
 module ThoralfPlugin.Variables where
 
 
+#if MIN_VERSION_ghc(9, 2, 0)
+import GHC.Core.Type ( TyVar )
+import GHC.Core.Coercion ( Var )
+import GHC.Types.Var ( isTcTyVar )
+import GHC.Tc.Utils.TcType ( isMetaTyVar )
+#else
 import Var ( TyVar, Var, isTcTyVar )
 import TcType ( isMetaTyVar )
+#endif
 
 data VarCat = Tau | Skol | Irr
   deriving Eq

--- a/test-suite-units/UoM.hs
+++ b/test-suite-units/UoM.hs
@@ -1,13 +1,18 @@
-{-# LANGUAGE TypeFamilies, GADTs, DataKinds #-}
+{-# LANGUAGE CPP, TypeFamilies, GADTs, DataKinds #-}
 
 {-# OPTIONS_GHC -fplugin ThoralfPlugin.Plugin #-}
 
 module UoM where
 
 import Data.Kind (Type)
-import Data.Singletons.TypeLits hiding (SSymbol)
 import ThoralfPlugin.Singletons.Symbol (SSymbol)
 import ThoralfPlugin.Theory.UoM
+
+#if MIN_VERSION_base(4, 16, 0)
+import GHC.TypeLits.Singletons hiding (SSymbol)
+#else
+import Data.Singletons.TypeLits hiding (SSymbol)
+#endif
 
 -- | Interface
 -------------------------------------------------------------

--- a/thoralf-plugin.cabal
+++ b/thoralf-plugin.cabal
@@ -76,9 +76,12 @@ Test-suite units
   ghc-options:           -Wall -fplugin ThoralfPlugin.Plugin
   build-depends:         base
                        , QuickCheck
-                       , singletons
                        , thoralf-plugin
                        , tasty
                        , tasty-hunit
                        , tasty-quickcheck
                        , tasty-th
+  if impl(ghc >= 9.2.0)
+    build-depends: singletons-base
+  else
+    build-depends: singletons < 3.0


### PR DESCRIPTION
Here's a problem compiling against ghc-9.2.1 that I'm not seeing with earlier compiler versions all the way back to ghc-8.2.2. I first noticed this with [plugins-for-blobs](https://github.com/BlockScope/plugins-for-blobs) and can reproduce it with `the-thoralf-plugin`.

```
> cabal build all --enable-tests
Resolving dependencies...
Build profile: -w ghc-9.2.1 -O1
In order, the following will be built (use -v for more details):
 - thoralf-plugin-0.1.0.0 (lib) (configuration changed)
 - thoralf-plugin-0.1.0.0 (test:units) (dependency rebuilt)
 - thoralf-plugin-0.1.0.0 (test:rows) (dependency rebuilt)
Configuring library for thoralf-plugin-0.1.0.0..
Preprocessing library for thoralf-plugin-0.1.0.0..
Building library for thoralf-plugin-0.1.0.0..
Preprocessing test suite 'units' for thoralf-plugin-0.1.0.0..
Preprocessing test suite 'rows' for thoralf-plugin-0.1.0.0..
Building test suite 'units' for thoralf-plugin-0.1.0.0..
Building test suite 'rows' for thoralf-plugin-0.1.0.0..
[1 of 4] Compiling FiniteMaps
[1 of 2] Compiling UoM

test-suite-rows/FiniteMaps.hs:1:1: error:
    Can't find interface-file declaration for type constructor or class GHC.TypeNats.<=?
      Probable cause: bug in .hi-boot file, or inconsistent .hi file
      Use -ddump-if-trace to get an idea of which file caused the error
  |
1 | {-# LANGUAGE TypeFamilies #-}
  | ^

test-suite-units/UoM.hs:1:1: error:
    Can't find interface-file declaration for type constructor or class GHC.TypeNats.<=?
      Probable cause: bug in .hi-boot file, or inconsistent .hi file
      Use -ddump-if-trace to get an idea of which file caused the error
  |
1 | {-# LANGUAGE TypeFamilies, GADTs, DataKinds #-}
  | ^
cabal: Failed to build test:rows from thoralf-plugin-0.1.0.0.
Failed to build test:units from thoralf-plugin-0.1.0.0.
```

This is only a problem when I build the tests.

```
> cabal build all --disable-tests
Build profile: -w ghc-9.2.1 -O1
In order, the following will be built (use -v for more details):
 - thoralf-plugin-0.1.0.0 (lib) (configuration changed)
Configuring library for thoralf-plugin-0.1.0.0..
Preprocessing library for thoralf-plugin-0.1.0.0..
Building library for thoralf-plugin-0.1.0.0..
```

If I can find a smaller reproduction of the problem then I'll submit an issue to GHC.